### PR TITLE
[issue#11535] 데이터 분석 차트 버튼/ 테이블 여백 간격 안맞는 부분 대응

### DIFF
--- a/src/assets/entry/scss/popup.scss
+++ b/src/assets/entry/scss/popup.scss
@@ -729,7 +729,7 @@
             border: 0;
             border: 1px solid #e2e2e2;
             border-radius: 4px;
-            line-height: 40px;
+            line-height: 38px;
             outline: 0;
             letter-spacing: -0.3px;
         }
@@ -2155,7 +2155,7 @@
             font-weight: 600;
             color: #555;
             text-align: center;
-            line-height: 30px;
+            line-height: 28px;
         }
         .tab_box {
             float: left;
@@ -2172,7 +2172,7 @@
                 font-size: 14px;
                 font-weight: 600;
                 text-align: center;
-                line-height: 30px;
+                line-height: 28px;
             }
             a {
                 display: block;
@@ -2256,7 +2256,7 @@
             font-weight: 600;
             color: #555;
             text-align: center;
-            line-height: 38px;
+            line-height: 36px;
         }
         .input_box .chart_del.disabled {
             background-color: #f9f9f9;
@@ -2279,7 +2279,7 @@
                 padding: 0 10px 0 11px;
                 font-size: 14px;
                 font-weight: 600;
-                line-height: 40px;
+                line-height: 36px;
             }
             li:after {
                 position: absolute;
@@ -2326,6 +2326,9 @@
         &.chart_state .input_inner input[type='text']:disabled {
             background-color: #f9f9f9;
             color: #cbcbcb;
+        }
+        &.chart_state .input_inner input[type='text']:disabled + .close_btn {
+            background-color: #f9f9f9;
         }
         &.chart_state .cont_inner {
             overflow: visible;

--- a/src/assets/entry/scss/table.scss
+++ b/src/assets/entry/scss/table.scss
@@ -7,7 +7,6 @@
         font-weight: bold;
         font-stretch: normal;
         font-style: normal;
-        line-height: 1.43;
         letter-spacing: -0.5px;
         text-align: center;
         color: #2c313d;
@@ -20,7 +19,6 @@
         font-weight: bold;
         font-stretch: normal;
         font-style: normal;
-        line-height: 1.43;
         letter-spacing: -0.5px;
         text-align: center;
         color: #2c313d;

--- a/src/components/ai_layout/DataDetail.jsx
+++ b/src/components/ai_layout/DataDetail.jsx
@@ -811,6 +811,9 @@ class DataDetail extends Component {
                                 </div>
                                 <div className={Styles.input_inner}>
                                     <input type="text" id="data2" name="data2" value="비활성화 컬러 테스트" disabled />
+                                    <a href="#" className={Styles.close_btn} role="button">
+                                        <span className={Styles.blind}>입력 취소</span>
+                                    </a>
                                 </div>
                                 <a href="#" className={Styles.chart_del}>차트 삭제</a>
                             </div>


### PR DESCRIPTION
https://oss.navercorp.com/entry/Entry/issues/11535
박윤혜 디자이너님이 말씀해주신 부분 중에 마크업으로 대응할 수 있는 부분을 수정하여 PR 드립니다.
데이터 분석 블록이 가려지는 이슈를 제외하고, 나머지 테이블 / 버튼 부분들의 line-height 값을 조정하여 대응 완료 하였습니다.  테이블 셀 부분은 플러그인이 사용된 것 같은데, 이부분의 line-height값을 제거 하였습니다.
혹시 다른 곳에 이슈가 발생하거나 사이드 이펙트가 발생한다면 말씀해주세요.
