### PR TITLE
[entry2-web/2745] 네비게이션 탭에 따라 페이지가 달라지도록 수정

### DIFF
--- a/src/components/popup/Contents/Projects/EmptyContents.jsx
+++ b/src/components/popup/Contents/Projects/EmptyContents.jsx
@@ -7,7 +7,27 @@ import { EMIT_TYPES as Types } from '@constants';
 import { triggerEvent } from '@actions/index';
 import { closePopup } from '@actions/popup';
 
-const Index = ({ makeProject }) => {
+const getResultMent = (type) => {
+    switch (type) {
+        case 'projects':
+            return (
+                <div>
+                    {CommonUtils.getLang('Menus.no_project_1')}
+                    <br />
+                    {CommonUtils.getLang('Menus.no_project_2')}
+                </div>
+            );
+            break;
+        case 'favorites':
+            return <div>{CommonUtils.getLang('Menus.no_marked_project')}</div>;
+            break;
+        default:
+            return <div>not supported type</div>;
+            break;
+    }
+};
+
+const Index = ({ makeProject, type }) => {
     const theme = Theme.getStyle('popup');
     return (
         <section className={classname(theme.pop_content, theme.art_content)}>
@@ -16,19 +36,17 @@ const Index = ({ makeProject }) => {
                 <h2 className={theme.blind}>{CommonUtils.getLang('Menus.my_project')}</h2>
                 <div className={theme.result_box}>
                     <div className={classname(theme.thmb, theme.imico_pop_mywrite_thmb)} />
-                    <p className={theme.result_dsc}>
-                        {CommonUtils.getLang('Menus.no_project_1')}
-                        <br />
-                        {CommonUtils.getLang('Menus.no_project_2')}
-                    </p>
-                    <div className={theme.pop_btn_box}>
-                        <div
-                            className={theme.active}
-                            onClick={CommonUtils.handleClick(makeProject)}
-                        >
-                            {CommonUtils.getLang('Menus.make_project')}
+                    <p className={theme.result_dsc}>{getResultMent(type)}</p>
+                    {type !== 'favorites' && (
+                        <div className={theme.pop_btn_box}>
+                            <div
+                                className={theme.active}
+                                onClick={CommonUtils.handleClick(makeProject)}
+                            >
+                                {CommonUtils.getLang('Menus.make_project')}
+                            </div>
                         </div>
-                    </div>
+                    )}
                 </div>
             </div>
         </section>
@@ -42,7 +60,4 @@ const mapDispatchToProps = (dispatch) => ({
     },
 });
 
-export default connect(
-    null,
-    mapDispatchToProps
-)(Index);
+export default connect(null, mapDispatchToProps)(Index);

--- a/src/components/popup/Contents/Projects/index.jsx
+++ b/src/components/popup/Contents/Projects/index.jsx
@@ -19,7 +19,7 @@ const Index = ({ type, data = [], avatarImage, closePopup, submit, fetch }) => {
     }, [type]);
 
     if (totalCount === 0) {
-        return <EmptyContents />;
+        return <EmptyContents type={type} />;
     }
     return (
         <>
@@ -73,7 +73,4 @@ const mapDispatchToProps = (dispatch) => ({
     closePopup: () => dispatch(closePopup()),
 });
 
-export default connect(
-    null,
-    mapDispatchToProps
-)(Index);
+export default connect(null, mapDispatchToProps)(Index);

--- a/src/components/popup/index.jsx
+++ b/src/components/popup/index.jsx
@@ -118,8 +118,6 @@ class Popup extends Component {
                 break;
             }
             case 'projects':
-                view = <Projects type={selected} data={data} />;
-                break;
             case 'favorites':
                 view = <Projects type={selected} data={data} />;
                 break;

--- a/src/components/popup/index.jsx
+++ b/src/components/popup/index.jsx
@@ -118,6 +118,8 @@ class Popup extends Component {
                 break;
             }
             case 'projects':
+                view = <Projects type={selected} data={data} />;
+                break;
             case 'favorites':
                 view = <Projects type={selected} data={data} />;
                 break;


### PR DESCRIPTION
### entry2-web 2745대응
- '온라인 작품 불러오기' > '관심 작품' 에서 안내 코멘트를 변경
  - 선택된 네비게이션 타입 정보 type(selected)를 Popup > Projects 컴포넌트에서 Popup > Projects > EmptyContents 컴포넌트로도 props로 전달.
  - 전달된 type정보를 기반으로 각기 다른 멘트가 출력되도록 로직 수정
- '작품 만들기' 버튼 삭제
  - 전달된 type정보를 기반으로 'favorites' 타입일 경우 버튼을 렌더링하지 않도록 수정