### PR TITLE
[#8917] fix: ledpicker width 계산식 수정

### DIFF
--- a/src/components/ledPicker/ledPicker.jsx
+++ b/src/components/ledPicker/ledPicker.jsx
@@ -31,7 +31,7 @@ class LedPicker extends Component {
     }
 
     get CONTAINER_WIDTH() {
-        return 24 + this.state.ledStatus.length * 39;
+        return 26 + this.state.ledStatus.length * 40;
     }
 
     get CONTAINER_HEIGHT() {


### PR DESCRIPTION
5*5 이하 사이즈에서 가로사이즈 꺠지는 현상 수정